### PR TITLE
Loosen requirements on `sources` and `categories`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureDescriptors"
 uuid = "cb0561c3-42a1-46a3-8749-4ae46de0afcc"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ All `Descriptor`s are required to implement the following:
 
 1. A `sources` method that specifies where to retrieve the data. A `Descriptor` may be associated with multiple sources, because it may be necessary to perform [feature engineering](https://invenia.github.io/FeatureTransforms.jl/stable/) to create the derived feature.
 1. A `quantity_key` method that denotes the name of the quantitative variable for the feature, such as `:temperature` or `:price`. For the sake of transparency and simplicity, only one `quantity_key` may be associated with a given `Descriptor`.
-1. A `categorical_keys` method that denotes the names of the categorical variables for the feature, such as `:colour` or `:type`. If no categorical variables are needed, this returns an empty vector.
+1. A `categorical_keys` method that denotes the names of the categorical variables for the feature, such as `:colour` or `:type`. If no categorical variables are needed, this returns an empty collection.
 
 You can ensure your `Descriptor` is implemented correctly by calling the [`TestUtils.test_interface`](https://invenia.github.io/FeatureDescriptors.jl/stable/index/#Testutils) function.

--- a/src/FeatureDescriptors.jl
+++ b/src/FeatureDescriptors.jl
@@ -21,10 +21,12 @@ the following methods:
 abstract type Descriptor end
 
 """
-    sources(::Descriptor) -> Vector{String}
+    sources(::Descriptor)
 
-Returns the data sources for the [`Descriptor`](@ref), e.g. the names or paths to the tables
-containing the required data: `["temperature.csv", "locations.csv"]`.
+Returns the data sources for the [`Descriptor`](@ref), e.g. the names of the tables that
+contain the required data: `["temperature.csv", "locations.csv"]`.
+
+Users are free to determine what kind of source is appropriate for a descriptor.
 """
 function sources end
 
@@ -36,10 +38,10 @@ Returns the quantitative variable for the [`Descriptor`](@ref), e.g. `:temperatu
 function quantity_key end
 
 """
-    categorical_keys(::Descriptor) -> Vector
+    categorical_keys(::Descriptor)
 
 Returns the categorical variables for the [`Descriptor`](@ref), e.g. `[:colour, :shape]`.
-Returns an empty vector if no categorical variables exist.
+If no categorical variables exist, this should be set to an empty collection.
 """
 function categorical_keys end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -29,10 +29,11 @@ Test that a subtype of [`Descriptor`](@ref) implements the expected API.
 """
 function test_interface(D)
     @testset "test_interface $D" begin
-        @test FeatureDescriptors.sources(D) isa Vector{String}
+        # We don't care what sources returns, just that an applicable method is defined.
+        @test applicable(FeatureDescriptors.sources, D)
         @test FeatureDescriptors.quantity_key(D) isa Symbol
         categories = FeatureDescriptors.categorical_keys(D)
-        @test (isempty(categories) || categories isa Vector{Symbol})
+        @test (isempty(categories) || eltype(categories) == Symbol)
         @test FeatureDescriptors.label(D) isa Symbol
     end
 end


### PR DESCRIPTION
- `sources` don't necessarily have to be Vector{String}, they can be whatever is appropriate for downstream uses.
- `categories` don't necessarily have to be a Vector either, they might be a Tuple.